### PR TITLE
cleanup: remove duplicate health endpoint, fix favorites blueprint consistency

### DIFF
--- a/app/routes/__init__.py
+++ b/app/routes/__init__.py
@@ -1,18 +1,5 @@
 """Routes package for the marketplace application."""
 
-from flask import Blueprint, jsonify
-
-# Create a simple health blueprint for /api/health
-health_bp = Blueprint('health', __name__)
-
-@health_bp.route('/health', methods=['GET'])
-def api_health():
-    """Health check endpoint at /api/health"""
-    return jsonify({
-        'status': 'ok',
-        'message': 'Backend is running!',
-        'version': '1.0.0'
-    }), 200
 
 def register_routes(app):
     """Register all route blueprints with the application."""
@@ -30,10 +17,7 @@ def register_routes(app):
     from .disputes import disputes_bp
     from .onboarding import onboarding_bp
 
-    # Register health check at /api/health
-    app.register_blueprint(health_bp, url_prefix='/api')
-    
-    # Register all other blueprints
+    # Register all blueprints with consistent url_prefix pattern
     app.register_blueprint(auth_bp, url_prefix='/api/auth')
     app.register_blueprint(listings_bp, url_prefix='/api/listings')
     app.register_blueprint(tasks_bp, url_prefix='/api/tasks')
@@ -42,7 +26,7 @@ def register_routes(app):
     app.register_blueprint(messages_bp, url_prefix='/api/messages')
     app.register_blueprint(offerings_bp, url_prefix='/api/offerings')
     app.register_blueprint(admin_bp, url_prefix='/api/admin')
-    app.register_blueprint(favorites_bp)  # Routes already have /api/favorites prefix
+    app.register_blueprint(favorites_bp, url_prefix='/api/favorites')
     app.register_blueprint(notifications_bp, url_prefix='/api/notifications')
     app.register_blueprint(push_bp, url_prefix='/api/push')
     app.register_blueprint(disputes_bp, url_prefix='/api/disputes')

--- a/app/routes/favorites.py
+++ b/app/routes/favorites.py
@@ -72,7 +72,7 @@ def get_item_details(item_type, item_id):
     return None
 
 
-@favorites_bp.route('/api/favorites', methods=['POST'])
+@favorites_bp.route('', methods=['POST'])
 @token_required
 def toggle_favorite(current_user_id):
     """Toggle favorite status for an item (add if not favorited, remove if already favorited)."""
@@ -102,7 +102,7 @@ def toggle_favorite(current_user_id):
     }), 200
 
 
-@favorites_bp.route('/api/favorites', methods=['GET'])
+@favorites_bp.route('', methods=['GET'])
 @token_required
 def get_favorites(current_user_id):
     """Get all favorites for the current user with full item details."""
@@ -126,7 +126,7 @@ def get_favorites(current_user_id):
     }), 200
 
 
-@favorites_bp.route('/api/favorites/check', methods=['GET'])
+@favorites_bp.route('/check', methods=['GET'])
 @token_required
 def check_favorites(current_user_id):
     """Check if multiple items are favorited by the current user.
@@ -152,7 +152,7 @@ def check_favorites(current_user_id):
     return jsonify({'favorites': result}), 200
 
 
-@favorites_bp.route('/api/favorites/<int:favorite_id>', methods=['DELETE'])
+@favorites_bp.route('/<int:favorite_id>', methods=['DELETE'])
 @token_required
 def remove_favorite(current_user_id, favorite_id):
     """Remove a specific favorite by its ID."""
@@ -167,7 +167,7 @@ def remove_favorite(current_user_id, favorite_id):
     return jsonify({'message': 'Favorite removed successfully'}), 200
 
 
-@favorites_bp.route('/api/favorites/item/<item_type>/<int:item_id>', methods=['DELETE'])
+@favorites_bp.route('/item/<item_type>/<int:item_id>', methods=['DELETE'])
 @token_required
 def remove_favorite_by_item(current_user_id, item_type, item_id):
     """Remove a favorite by item type and ID."""
@@ -189,7 +189,7 @@ def remove_favorite_by_item(current_user_id, item_type, item_id):
     return jsonify({'message': 'Favorite removed successfully'}), 200
 
 
-@favorites_bp.route('/api/favorites/count', methods=['GET'])
+@favorites_bp.route('/count', methods=['GET'])
 @token_required
 def get_favorites_count(current_user_id):
     """Get count of user's favorites by type."""


### PR DESCRIPTION
## What

Two route cleanup fixes in one PR.

### 1. Removed duplicate health blueprint

**Before**: Two health endpoints existed:
- `/health` in `create_app()` — returns `{status, environment, database_configured}` (useful)
- `/api/health` in `routes/__init__.py` — returns `{status: 'ok', message: 'Backend is running!', version: '1.0.0'}` (generic fluff)

**After**: Only `/health` in `create_app()` remains. It has actual diagnostic info. The `health_bp` blueprint, its import, and its registration are all removed from `routes/__init__.py`.

### 2. Fixed favorites blueprint to use `url_prefix`

**Before**: `favorites_bp` was the only blueprint registered without `url_prefix`. All 6 route decorators hardcoded `/api/favorites`:
```python
app.register_blueprint(favorites_bp)  # Routes already have /api/favorites prefix

@favorites_bp.route('/api/favorites', methods=['POST'])
@favorites_bp.route('/api/favorites', methods=['GET'])
@favorites_bp.route('/api/favorites/check', methods=['GET'])
@favorites_bp.route('/api/favorites/<int:favorite_id>', methods=['DELETE'])
@favorites_bp.route('/api/favorites/item/<item_type>/<int:item_id>', methods=['DELETE'])
@favorites_bp.route('/api/favorites/count', methods=['GET'])
```

**After**: Consistent with every other blueprint:
```python
app.register_blueprint(favorites_bp, url_prefix='/api/favorites')

@favorites_bp.route('', methods=['POST'])
@favorites_bp.route('', methods=['GET'])
@favorites_bp.route('/check', methods=['GET'])
@favorites_bp.route('/<int:favorite_id>', methods=['DELETE'])
@favorites_bp.route('/item/<item_type>/<int:item_id>', methods=['DELETE'])
@favorites_bp.route('/count', methods=['GET'])
```

## API impact

- `/api/health` — **removed** (use `/health` instead)
- All `/api/favorites/*` endpoints — **unchanged** (same URLs, same behavior)

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ▶️ 2 queued — [View all](https://hub.continue.dev/inbox/pr/ojayWillow/marketplace-backend/27?utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->