### PR TITLE
feat: add rate limiting, input validation, and request size limits

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ Flask-Migrate==4.0.5
 Flask-CORS==4.0.0
 Flask-JWT-Extended==4.5.2
 Flask-SocketIO==5.4.1
+Flask-Limiter==3.5.0
 python-socketio==5.11.4
 gevent>=24.10.1
 gevent-websocket>=0.10.1


### PR DESCRIPTION
## What this adds

### 1. Rate Limiting (`flask-limiter`)

Added per-endpoint rate limits on the most abuse-prone routes:

| Endpoint | Limit | Why |
|---|---|---|
| `/register` | 5/min | Prevent mass account creation |
| `/login` | 10/min | Block brute-force password attacks |
| `/phone/send-otp` | 3/min | Prevent SMS spam (costs money too) |
| `/phone/verify-otp` | 5/min | Block OTP brute-force |
| `/forgot-password` | 3/min | Prevent email spam |
| **Global default** | 200/day, 50/hour | Catch-all for all other routes |

Rate limiting is automatically disabled in the `testing` environment so tests aren't affected.

Uses in-memory storage (`memory://`). For multi-worker production deployments, consider switching to Redis (`redis://localhost:6379`).

### 2. Input Validation on `/register`

| Field | Validation |
|---|---|
| `username` | 3-30 chars, alphanumeric + underscores only (regex) |
| `email` | RFC-style regex validation, max 254 chars |
| `password` | 6-128 chars |
| `first_name` | Max 50 chars (optional) |
| `last_name` | Max 50 chars (optional) |

Previously: no email format check, no username constraints, no max length on any field.

### 3. `MAX_CONTENT_LENGTH = 16MB`

Flask now rejects request bodies larger than 16MB **before** reading them into memory. Previously, the upload routes read the entire file with `file.read()` before checking size — meaning a 500MB upload would consume 500MB of server memory before being rejected.

## Files changed

- **`requirements.txt`** — Added `Flask-Limiter==3.5.0`
- **`app/__init__.py`** — Initialize limiter, set `MAX_CONTENT_LENGTH`, disable limiter in tests
- **`app/routes/auth.py`** — Rate limit decorators on 5 endpoints, input validation on `/register`

## After merging

Run `pip install -r requirements.txt` to install `flask-limiter`.

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ▶️ 2 queued — [View all](https://hub.continue.dev/inbox/pr/ojayWillow/marketplace-backend/31?utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->