### PR TITLE
fix(tasks/crud): stop leaking internal error details to clients

### DIFF
--- a/app/routes/tasks/crud.py
+++ b/app/routes/tasks/crud.py
@@ -7,8 +7,7 @@ including geo-search with smart radius expansion.
 import logging
 from datetime import datetime
 from flask import request, jsonify, current_app
-from sqlalchemy import func, or_, and_, text
-from sqlalchemy.orm import joinedload
+from sqlalchemy import func, or_
 
 from app import db
 from app.models import TaskRequest, TaskApplication, User, Notification, NotificationType, Review
@@ -287,7 +286,7 @@ def get_tasks():
             }), 200
 
     except Exception as e:
-        return jsonify({'error': str(e)}), 500
+        raise
 
 
 @tasks_bp.route('/<int:task_id>', methods=['GET'])
@@ -319,7 +318,7 @@ def get_task(task_id):
 
         return jsonify(task_data), 200
     except Exception as e:
-        return jsonify({'error': str(e)}), 500
+        raise
 
 
 # ---------------------------------------------------------------------------
@@ -357,10 +356,10 @@ def create_task(current_user_id):
         # Validate text field lengths
         if len(data['title']) > 200:
             return jsonify({'error': 'Title must be less than 200 characters'}), 400
-        
+
         if len(data['description']) > 5000:
             return jsonify({'error': 'Description must be less than 5000 characters'}), 400
-        
+
         if len(data['location']) > 200:
             return jsonify({'error': 'Location must be less than 200 characters'}), 400
 
@@ -471,7 +470,7 @@ def create_task(current_user_id):
 
     except Exception as e:
         db.session.rollback()
-        return jsonify({'error': str(e)}), 500
+        raise
 
 
 @tasks_bp.route('/<int:task_id>', methods=['PUT'])
@@ -570,4 +569,4 @@ def update_task(current_user_id, task_id):
 
     except Exception as e:
         db.session.rollback()
-        return jsonify({'error': str(e)}), 500
+        raise


### PR DESCRIPTION
Remove `str(e)` from all 4 route-level except blocks in `tasks/crud.py`. Exceptions now re-raise to the global error handler.

- `get_tasks`, `get_task`: bare `raise` (read-only)
- `create_task`, `update_task`: kept `db.session.rollback()`, then `raise`
- Removed unused imports (`text`, `joinedload`, `and_`)
- Left job alert + JWT inner try/except untouched (intentional)

Part of #32

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ▶️ 2 queued — [View all](https://hub.continue.dev/inbox/pr/ojayWillow/marketplace-backend/36?utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->