### PR TITLE
feat: Redis Socket.IO message queue + 3 Gunicorn workers

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -23,3 +23,4 @@ resend==0.8.0
 vonage>=4.0.0
 vonage-sms>=1.1.0
 supabase>=2.0.0
+redis>=5.0.0

--- a/start.sh
+++ b/start.sh
@@ -49,10 +49,12 @@ echo "[MIGRATION] Completed"
 
 # Start gunicorn with gevent worker for async support
 # Flask-SocketIO with async_mode='gevent' handles Socket.IO connections internally
-echo "Starting gunicorn on port $PORT..."
+# Using 3 workers for better throughput. Redis message queue (REDIS_URL) is required
+# for Socket.IO to work correctly across multiple workers.
+echo "Starting gunicorn on port $PORT with 3 workers..."
 exec gunicorn patched_app:application \
     --worker-class gevent \
-    -w 1 \
+    -w 3 \
     --bind 0.0.0.0:$PORT \
     --timeout 120 \
     --log-level info


### PR DESCRIPTION
## What this does

Enables **multi-worker Gunicorn** (3 workers) with **Redis as the Socket.IO message queue**, so chat messages and real-time events are reliably delivered across all workers.

## Changes (3 files, minimal diff)

### 1. `requirements.txt`
- Added `redis>=5.0.0` — required by Flask-SocketIO for message queue support

### 2. `app/__init__.py`
- Reads `REDIS_URL` from environment variables
- Passes it as `message_queue=redis_url` to `socketio.init_app()`
- Adds `channel='kolab-socketio'` to namespace the pub/sub (avoids cross-talk if Redis is shared)
- **Graceful fallback**: if `REDIS_URL` is not set, Socket.IO runs without a queue (single-worker mode for local dev)

### 3. `start.sh`
- Changed `-w 1` → `-w 3` (3 Gunicorn gevent workers)
- Updated log message to reflect worker count

## Why

- With 1 worker, all HTTP + Socket.IO connections queue behind a single process
- 3 workers = ~3x throughput for API requests
- Redis ensures Socket.IO events (messages, typing indicators, etc.) reach clients regardless of which worker they're connected to

## Prerequisites

- ✅ Redis service added on Railway
- ✅ `REDIS_URL` environment variable set on backend service

## Testing after merge

1. Open two browsers (or browser + incognito)
2. Login as two different users
3. Open the same conversation
4. Send messages both ways for 2-3 minutes
5. Refresh tabs while chatting — messages should still deliver reliably

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ▶️ 2 queued — [View all](https://hub.continue.dev/inbox/pr/ojayWillow/marketplace-backend/39?utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->