### PR TITLE
fix(security): remove all remaining str(e) error leaks — 20 routes across 3 files

### DIFF
--- a/app/routes/listings.py
+++ b/app/routes/listings.py
@@ -36,8 +36,8 @@ def get_listings():
         listings = query.paginate(page=page, per_page=per_page)
         
         return jsonify([listing.to_dict() for listing in listings.items]), 200
-    except Exception as e:
-        return jsonify({'error': str(e)}), 500
+    except Exception:
+        raise
 
 
 @listings_bp.route('/my', methods=['GET'])
@@ -64,8 +64,8 @@ def get_my_listings(current_user_id):
             'pages': listings.pages,
             'current_page': page
         }), 200
-    except Exception as e:
-        return jsonify({'error': str(e)}), 500
+    except Exception:
+        raise
 
 
 @listings_bp.route('/user/<int:user_id>', methods=['GET'])
@@ -92,8 +92,8 @@ def get_user_listings(user_id):
             'pages': listings.pages,
             'current_page': page
         }), 200
-    except Exception as e:
-        return jsonify({'error': str(e)}), 500
+    except Exception:
+        raise
 
 
 @listings_bp.route('/<int:listing_id>', methods=['GET'])
@@ -108,8 +108,8 @@ def get_listing(listing_id):
         db.session.commit()
         
         return jsonify(listing.to_dict(include_seller_details=True)), 200
-    except Exception as e:
-        return jsonify({'error': str(e)}), 500
+    except Exception:
+        raise
 
 
 @listings_bp.route('', methods=['POST'])
@@ -145,9 +145,9 @@ def create_listing(current_user_id):
             'message': 'Listing created successfully',
             'listing': listing.to_dict()
         }), 201
-    except Exception as e:
+    except Exception:
         db.session.rollback()
-        return jsonify({'error': str(e)}), 500
+        raise
 
 
 @listings_bp.route('/<int:listing_id>', methods=['PUT'])
@@ -180,9 +180,9 @@ def update_listing(current_user_id, listing_id):
             'message': 'Listing updated successfully',
             'listing': listing.to_dict()
         }), 200
-    except Exception as e:
+    except Exception:
         db.session.rollback()
-        return jsonify({'error': str(e)}), 500
+        raise
 
 
 @listings_bp.route('/<int:listing_id>', methods=['DELETE'])
@@ -201,6 +201,6 @@ def delete_listing(current_user_id, listing_id):
         db.session.commit()
         
         return jsonify({'message': 'Listing deleted successfully'}), 200
-    except Exception as e:
+    except Exception:
         db.session.rollback()
-        return jsonify({'error': str(e)}), 500
+        raise

--- a/app/routes/offerings.py
+++ b/app/routes/offerings.py
@@ -176,8 +176,8 @@ def get_offerings():
                 'page': page
             }), 200
             
-    except Exception as e:
-        return jsonify({'error': str(e)}), 500
+    except Exception:
+        raise
 
 
 @offerings_bp.route('/my', methods=['GET'])
@@ -197,8 +197,8 @@ def get_my_offerings():
             'page': 1
         }), 200
         
-    except Exception as e:
-        return jsonify({'error': str(e)}), 500
+    except Exception:
+        raise
 
 
 @offerings_bp.route('/user/<int:user_id>', methods=['GET'])
@@ -226,8 +226,8 @@ def get_user_offerings(user_id):
             'page': 1
         }), 200
         
-    except Exception as e:
-        return jsonify({'error': str(e)}), 500
+    except Exception:
+        raise
 
 
 @offerings_bp.route('/<int:offering_id>', methods=['GET'])
@@ -245,8 +245,8 @@ def get_offering(offering_id):
         offering_dict = translate_offering_if_needed(offering.to_dict(), lang)
         return jsonify(offering_dict), 200
         
-    except Exception as e:
-        return jsonify({'error': str(e)}), 500
+    except Exception:
+        raise
 
 
 @offerings_bp.route('', methods=['POST'])
@@ -301,9 +301,9 @@ def create_offering():
             'offering': offering.to_dict()
         }), 201
         
-    except Exception as e:
+    except Exception:
         db.session.rollback()
-        return jsonify({'error': str(e)}), 500
+        raise
 
 
 @offerings_bp.route('/<int:offering_id>', methods=['PUT'])
@@ -354,9 +354,9 @@ def update_offering(offering_id):
             'offering': offering.to_dict()
         }), 200
         
-    except Exception as e:
+    except Exception:
         db.session.rollback()
-        return jsonify({'error': str(e)}), 500
+        raise
 
 
 @offerings_bp.route('/<int:offering_id>', methods=['DELETE'])
@@ -378,9 +378,9 @@ def delete_offering(offering_id):
         
         return jsonify({'message': 'Offering deleted successfully'}), 200
         
-    except Exception as e:
+    except Exception:
         db.session.rollback()
-        return jsonify({'error': str(e)}), 500
+        raise
 
 
 @offerings_bp.route('/<int:offering_id>/pause', methods=['POST'])
@@ -405,9 +405,9 @@ def pause_offering(offering_id):
             'offering': offering.to_dict()
         }), 200
         
-    except Exception as e:
+    except Exception:
         db.session.rollback()
-        return jsonify({'error': str(e)}), 500
+        raise
 
 
 @offerings_bp.route('/<int:offering_id>/activate', methods=['POST'])
@@ -432,9 +432,9 @@ def activate_offering(offering_id):
             'offering': offering.to_dict()
         }), 200
         
-    except Exception as e:
+    except Exception:
         db.session.rollback()
-        return jsonify({'error': str(e)}), 500
+        raise
 
 
 @offerings_bp.route('/<int:offering_id>/boost', methods=['POST'])
@@ -473,9 +473,9 @@ def boost_offering(offering_id):
             'boost_expires_at': offering.boost_expires_at.isoformat()
         }), 200
         
-    except Exception as e:
+    except Exception:
         db.session.rollback()
-        return jsonify({'error': str(e)}), 500
+        raise
 
 
 @offerings_bp.route('/<int:offering_id>/contact', methods=['POST'])
@@ -531,6 +531,6 @@ def contact_offering_creator(offering_id):
             'conversation_id': conversation.id
         }), 201
         
-    except Exception as e:
+    except Exception:
         db.session.rollback()
-        return jsonify({'error': str(e)}), 500
+        raise

--- a/app/routes/onboarding.py
+++ b/app/routes/onboarding.py
@@ -85,9 +85,9 @@ def complete_onboarding(current_user_id):
             'user': user.to_dict()
         }), 200
         
-    except Exception as e:
+    except Exception:
         db.session.rollback()
-        return jsonify({'error': str(e)}), 500
+        raise
 
 
 @onboarding_bp.route('/onboarding-status', methods=['GET'])
@@ -137,5 +137,5 @@ def onboarding_status(current_user_id):
             }
         }), 200
         
-    except Exception as e:
-        return jsonify({'error': str(e)}), 500
+    except Exception:
+        raise


### PR DESCRIPTION
## What this does

Removes the **last 20 `str(e)` error leaks** in the codebase. After this PR + PR #40, **zero routes** will leak internal error details to API consumers.

## Changes

| File | Leaking routes fixed | 
|---|---|
| `offerings.py` | 11 — `get_offerings`, `get_my_offerings`, `get_user_offerings`, `get_offering`, `create_offering`, `update_offering`, `delete_offering`, `pause_offering`, `activate_offering`, `boost_offering`, `contact_offering_creator` |
| `listings.py` | 7 — `get_listings`, `get_my_listings`, `get_user_listings`, `get_listing`, `create_listing`, `update_listing`, `delete_listing` |
| `onboarding.py` | 2 — `complete_onboarding`, `onboarding_status` |

## What was wrong

Every `except` block was doing:
```python
except Exception as e:
    return jsonify({'error': str(e)}), 500
```

This leaks internal details like database errors, file paths, and stack information directly to API consumers.

## The fix

All replaced with:
```python
except Exception:
    db.session.rollback()  # where applicable
    raise
```

The bare `raise` lets Flask's global error handler (added in PR #35) return a safe generic `{"error": "Internal server error"}` response while still logging the full exception server-side.

## Files already clean (no changes needed)

- `disputes.py` — returns specific error messages, no `str(e)` patterns
- `uploads.py` — uses `logger` properly, no leaks
- `favorites.py` — no try/except blocks wrapping routes

## Full codebase status after merge

With PR #40 (auth split) + this PR, every route file in `app/routes/` will be leak-free.

Part of #32

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ▶️ 2 queued — [View all](https://hub.continue.dev/inbox/pr/ojayWillow/marketplace-backend/41?utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->