### PR TITLE
Add images field handling to task update route

### DIFF
--- a/app/routes/tasks/crud.py
+++ b/app/routes/tasks/crud.py
@@ -536,6 +536,9 @@ def update_task(current_user_id, task_id):
                 return jsonify({'error': 'Invalid difficulty. Must be easy, medium, or hard'}), 400
             task.difficulty = data['difficulty']
         
+        if 'images' in data:
+            task.images = data['images']
+        
         task.updated_at = datetime.utcnow()
         db.session.commit()
         


### PR DESCRIPTION
## Problem

The `update_task` route in `app/routes/tasks/crud.py` did not handle the `images` field. When a user edited a task and sent updated image URLs, they were silently ignored.

The offering update route (`app/routes/offerings.py`) already included `images` in its `updateable_fields` list — this brings task updates to parity.

## Change

Added `images` handling to `update_task()` in `app/routes/tasks/crud.py`:

```python
if 'images' in data:
    task.images = data['images']
```

This is placed alongside the other optional field updates (after `difficulty`, before `updated_at`).

## Context

- The `TaskRequest` model already has `images = db.Column(db.JSON, nullable=True)`
- The `to_dict()` method already returns `'images': self.images`
- The create route already handles images: `images=data.get('images')`
- Companion frontend PR: `ojayWillow/marketplace-frontend#fix/image-field-alignment`

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ▶️ 2 queued — [View all](https://hub.continue.dev/inbox/pr/ojayWillow/marketplace-backend/43?utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->