### PR TITLE
fix: add images field to task update route

### DIFF
--- a/app/routes/tasks/crud.py
+++ b/app/routes/tasks/crud.py
@@ -536,6 +536,9 @@ def update_task(current_user_id, task_id):
                 return jsonify({'error': 'Invalid difficulty. Must be easy, medium, or hard'}), 400
             task.difficulty = data['difficulty']
         
+        if 'images' in data:
+            task.images = data['images']
+        
         task.updated_at = datetime.utcnow()
         db.session.commit()
         


### PR DESCRIPTION
## What this fixes

The `PUT /api/tasks/<id>` route was missing `images` from its updatable fields.

- Offerings update route already handled `images` correctly
- Task update route silently ignored any `images` data sent by the frontend
- Added `if 'images' in data: task.images = data['images']` to the update handler

Paired with marketplace-frontend PR #172 which fixes the field name mismatch and adds image support to Edit forms.

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ▶️ 2 queued — [View all](https://hub.continue.dev/inbox/pr/ojayWillow/marketplace-backend/44?utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->