### PR TITLE
feat(auth): add Supabase auth client and shared client module

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,7 +19,8 @@ FROM_EMAIL=noreply@yourdomain.com
 FROM_NAME=Marketplace
 FRONTEND_URL=https://marketplace-frontend-tau-seven.vercel.app
 
-# Supabase Storage Configuration
+# Supabase Configuration
 # Get these from: Supabase Dashboard -> Settings -> API
 SUPABASE_URL=https://your-project.supabase.co
 SUPABASE_SERVICE_KEY=your-service-role-key
+SUPABASE_JWT_SECRET=your-jwt-secret-from-supabase-dashboard

--- a/app/services/storage.py
+++ b/app/services/storage.py
@@ -7,37 +7,12 @@ Buckets:
 - chat-images: Chat message attachments (authenticated)
 """
 
-import os
 import logging
 from uuid import uuid4
 from typing import Optional, Tuple
+from app.services.supabase_client import get_supabase_client
 
 logger = logging.getLogger(__name__)
-
-# Supabase client (lazy initialization)
-_supabase_client = None
-
-def get_supabase_client():
-    """Get or create Supabase client (lazy initialization)."""
-    global _supabase_client
-    
-    if _supabase_client is None:
-        url = os.getenv('SUPABASE_URL')
-        key = os.getenv('SUPABASE_SERVICE_KEY')
-        
-        if not url or not key:
-            logger.warning('Supabase credentials not configured. Storage will not work.')
-            return None
-        
-        try:
-            from supabase import create_client
-            _supabase_client = create_client(url, key)
-            logger.info('Supabase client initialized successfully')
-        except Exception as e:
-            logger.error(f'Failed to initialize Supabase client: {e}')
-            return None
-    
-    return _supabase_client
 
 
 def is_storage_configured() -> bool:
@@ -52,43 +27,43 @@ def upload_file(
     content_type: str = 'image/jpeg'
 ) -> Tuple[Optional[str], Optional[str]]:
     """Upload a file to Supabase Storage.
-    
+
     Args:
         bucket: Storage bucket name ('avatars', 'task-images', 'chat-images')
         file_data: Raw file bytes
         file_name: Original filename (used to get extension)
         content_type: MIME type of the file
-    
+
     Returns:
         Tuple of (public_url, error_message)
         If successful: (url, None)
         If failed: (None, error_message)
     """
     client = get_supabase_client()
-    
+
     if client is None:
         return None, 'Storage service not configured'
-    
+
     try:
         # Generate unique filename
         ext = file_name.rsplit('.', 1)[-1].lower() if '.' in file_name else 'jpg'
         unique_name = f"{uuid4().hex}.{ext}"
-        
+
         logger.info(f'Uploading file to {bucket}/{unique_name} ({content_type})')
-        
+
         # Upload to Supabase
         result = client.storage.from_(bucket).upload(
             path=unique_name,
             file=file_data,
             file_options={"content-type": content_type}
         )
-        
+
         # Get public URL
         public_url = client.storage.from_(bucket).get_public_url(unique_name)
-        
+
         logger.info(f'File uploaded successfully: {public_url}')
         return public_url, None
-        
+
     except Exception as e:
         error_msg = str(e)
         logger.error(f'Upload failed: {error_msg}')
@@ -97,33 +72,33 @@ def upload_file(
 
 def delete_file(bucket: str, file_url: str) -> Tuple[bool, Optional[str]]:
     """Delete a file from Supabase Storage.
-    
+
     Args:
         bucket: Storage bucket name
         file_url: Full public URL or just the filename
-    
+
     Returns:
         Tuple of (success, error_message)
     """
     client = get_supabase_client()
-    
+
     if client is None:
         return False, 'Storage service not configured'
-    
+
     try:
         # Extract filename from URL if full URL provided
         if '/' in file_url:
             file_name = file_url.split('/')[-1]
         else:
             file_name = file_url
-        
+
         logger.info(f'Deleting file from {bucket}/{file_name}')
-        
+
         client.storage.from_(bucket).remove([file_name])
-        
+
         logger.info(f'File deleted successfully: {file_name}')
         return True, None
-        
+
     except Exception as e:
         error_msg = str(e)
         logger.error(f'Delete failed: {error_msg}')

--- a/app/services/supabase_auth.py
+++ b/app/services/supabase_auth.py
@@ -1,0 +1,151 @@
+"""Supabase Auth admin operations.
+
+Uses the Supabase service-role client to perform admin auth operations:
+- Creating users (for phone auth flow)
+- Generating session tokens
+- Looking up users by email/phone
+
+Note: These use the SERVICE_KEY (admin access). Never expose to frontend.
+"""
+
+import logging
+from typing import Optional
+from app.services.supabase_client import get_supabase_client
+
+logger = logging.getLogger(__name__)
+
+
+def create_supabase_user(
+    email: Optional[str] = None,
+    phone: Optional[str] = None,
+    password: Optional[str] = None,
+    email_confirm: bool = True,
+    phone_confirm: bool = True,
+    user_metadata: Optional[dict] = None,
+) -> dict:
+    """Create a new user in Supabase Auth.
+
+    Args:
+        email: User email address
+        phone: User phone number (E.164 format)
+        password: User password (if None, generates a random one)
+        email_confirm: Skip email verification
+        phone_confirm: Skip phone verification
+        user_metadata: Additional metadata to store
+
+    Returns:
+        Supabase user object dict
+
+    Raises:
+        Exception if creation fails
+    """
+    client = get_supabase_client()
+    if not client:
+        raise RuntimeError('Supabase client not available')
+
+    import secrets
+    if not password:
+        password = secrets.token_urlsafe(32)
+
+    attrs = {'password': password}
+    if email:
+        attrs['email'] = email
+        attrs['email_confirm'] = email_confirm
+    if phone:
+        attrs['phone'] = phone
+        attrs['phone_confirm'] = phone_confirm
+    if user_metadata:
+        attrs['user_metadata'] = user_metadata
+
+    response = client.auth.admin.create_user(attrs)
+    logger.info(f'Supabase user created: {response.user.id}')
+    return response.user
+
+
+def get_supabase_user_by_id(user_id: str):
+    """Get a Supabase Auth user by their UUID."""
+    client = get_supabase_client()
+    if not client:
+        raise RuntimeError('Supabase client not available')
+
+    response = client.auth.admin.get_user_by_id(user_id)
+    return response.user
+
+
+def get_supabase_user_by_email(email: str):
+    """Look up a Supabase Auth user by email.
+
+    Returns None if not found.
+    """
+    client = get_supabase_client()
+    if not client:
+        raise RuntimeError('Supabase client not available')
+
+    try:
+        users = client.auth.admin.list_users()
+        for user in users:
+            if hasattr(user, 'email') and user.email == email:
+                return user
+    except Exception as e:
+        logger.error(f'Error looking up user by email: {e}')
+    return None
+
+
+def get_supabase_user_by_phone(phone: str):
+    """Look up a Supabase Auth user by phone number.
+
+    Returns None if not found.
+    """
+    client = get_supabase_client()
+    if not client:
+        raise RuntimeError('Supabase client not available')
+
+    try:
+        users = client.auth.admin.list_users()
+        for user in users:
+            if hasattr(user, 'phone') and user.phone == phone:
+                return user
+    except Exception as e:
+        logger.error(f'Error looking up user by phone: {e}')
+    return None
+
+
+def generate_link_for_user(
+    user_id: str,
+    link_type: str = 'magiclink',
+) -> dict:
+    """Generate an auth link for a user (e.g., magic link, recovery).
+
+    Args:
+        user_id: Supabase user UUID
+        link_type: Type of link ('magiclink', 'recovery', 'invite')
+
+    Returns:
+        Link properties dict
+    """
+    client = get_supabase_client()
+    if not client:
+        raise RuntimeError('Supabase client not available')
+
+    user = get_supabase_user_by_id(user_id)
+    if not user:
+        raise ValueError(f'User {user_id} not found')
+
+    attrs = {'type': link_type, 'email': user.email}
+    response = client.auth.admin.generate_link(attrs)
+    return response
+
+
+def delete_supabase_user(user_id: str) -> bool:
+    """Delete a user from Supabase Auth."""
+    client = get_supabase_client()
+    if not client:
+        raise RuntimeError('Supabase client not available')
+
+    try:
+        client.auth.admin.delete_user(user_id)
+        logger.info(f'Supabase user deleted: {user_id}')
+        return True
+    except Exception as e:
+        logger.error(f'Failed to delete Supabase user {user_id}: {e}')
+        return False

--- a/app/services/supabase_client.py
+++ b/app/services/supabase_client.py
@@ -1,0 +1,48 @@
+"""Shared Supabase client.
+
+Single source of truth for the Supabase client instance.
+Used by storage, auth, and any other service that needs Supabase.
+"""
+
+import os
+import logging
+
+logger = logging.getLogger(__name__)
+
+_supabase_client = None
+
+
+def get_supabase_client():
+    """Get or create Supabase client (lazy initialization)."""
+    global _supabase_client
+
+    if _supabase_client is None:
+        url = os.getenv('SUPABASE_URL')
+        key = os.getenv('SUPABASE_SERVICE_KEY')
+
+        if not url or not key:
+            logger.warning('Supabase credentials not configured.')
+            return None
+
+        try:
+            from supabase import create_client
+            _supabase_client = create_client(url, key)
+            logger.info('Supabase client initialized successfully')
+        except Exception as e:
+            logger.error(f'Failed to initialize Supabase client: {e}')
+            return None
+
+    return _supabase_client
+
+
+def get_supabase_jwt_secret() -> str:
+    """Get the Supabase JWT secret for token verification.
+
+    This is the JWT secret from Supabase Dashboard > Settings > API.
+    Used by auth decorators to decode Supabase-issued JWTs.
+    """
+    secret = os.getenv('SUPABASE_JWT_SECRET')
+    if not secret:
+        logger.error('SUPABASE_JWT_SECRET not configured!')
+        raise ValueError('SUPABASE_JWT_SECRET environment variable is required')
+    return secret


### PR DESCRIPTION
Closes #49

## What
Sets up the Supabase Auth foundation for the migration (parent: #48).

## Changes

### New files
- **`app/services/supabase_client.py`** — Shared Supabase client (single source of truth). Extracts the lazy-init pattern from `storage.py`. Also exposes `get_supabase_jwt_secret()` for the upcoming decorator changes (#50).
- **`app/services/supabase_auth.py`** — Auth admin operations: create users, look up by email/phone, generate links, delete users. Used by #51 (sync-user), #52 (phone/verify), and #54 (migration script).

### Modified files
- **`app/services/storage.py`** — Now imports from `supabase_client.py` instead of having its own client init. Same behavior, no duplication.
- **`.env.example`** — Added `SUPABASE_JWT_SECRET` (from Supabase Dashboard → Settings → API)

### What this does NOT change
- No auth flow changes yet — existing JWT auth still works
- No model changes — `supabase_user_id` column comes in #50
- No frontend changes needed

## Next step
→ #50: Replace `token_required` decorators to decode Supabase JWTs

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ▶️ 2 queued — [View all](https://hub.continue.dev/inbox/pr/ojayWillow/marketplace-backend/55?utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->