### PR TITLE
feat(auth): replace JWT decorators for Supabase + add supabase_user_id

### DIFF
--- a/app/models/user.py
+++ b/app/models/user.py
@@ -21,6 +21,7 @@ class User(db.Model):
     __tablename__ = 'users'
     
     id = db.Column(db.Integer, primary_key=True)
+    supabase_user_id = db.Column(db.String(36), unique=True, nullable=True, index=True)  # Supabase Auth UUID
     username = db.Column(db.String(80), unique=True, nullable=False, index=True)
     email = db.Column(db.String(120), unique=True, nullable=False, index=True)
     phone = db.Column(db.String(20), nullable=True)

--- a/app/utils/auth.py
+++ b/app/utils/auth.py
@@ -2,6 +2,12 @@
 
 This module provides JWT authentication decorators that can be used
 across all route files to ensure consistent authentication behavior.
+
+Supports TWO token types during migration:
+1. Supabase JWT (primary) - decoded using SUPABASE_JWT_SECRET, user looked up by `sub` -> supabase_user_id
+2. Legacy custom JWT (temporary) - decoded using JWT_SECRET_KEY, user looked up by `user_id` in payload
+
+Once all users are migrated to Supabase Auth, remove the legacy fallback (tracked in #53).
 """
 
 from functools import wraps
@@ -9,156 +15,152 @@ from flask import request, jsonify, current_app, g
 import jwt
 import os
 
-# Use JWT_SECRET_KEY consistently across all routes
+# Legacy secret (kept for backward compatibility during migration)
 SECRET_KEY = os.getenv('JWT_SECRET_KEY', 'your-secret-key-here')
 
 
-def token_required(f):
+def _get_supabase_jwt_secret():
+    """Get Supabase JWT secret, return None if not configured."""
+    return os.getenv('SUPABASE_JWT_SECRET')
+
+
+def _resolve_user_from_token(auth_header):
+    """Decode token and resolve to local user_id.
+
+    Tries Supabase JWT first, falls back to legacy custom JWT.
+
+    Returns:
+        (user_id, error_message, status_code)
+        On success: (user_id, None, None)
+        On failure: (None, error_string, http_status)
     """
-    Decorator to require valid JWT token.
-    
-    Extracts user_id from JWT token and passes it as the first argument
-    to the decorated function.
-    
-    Usage:
-        @app.route('/protected')
-        @token_required
-        def protected_route(current_user_id):
-            # current_user_id is extracted from JWT
-            return jsonify({'user_id': current_user_id})
+    try:
+        token = auth_header.split(' ')[1] if ' ' in auth_header else auth_header
+    except (IndexError, AttributeError):
+        return None, 'Token is missing', 401
+
+    # --- Attempt 1: Supabase JWT ---
+    supabase_secret = _get_supabase_jwt_secret()
+    if supabase_secret:
+        try:
+            payload = jwt.decode(token, supabase_secret, algorithms=['HS256'], audience='authenticated')
+            supabase_uid = payload.get('sub')
+            if supabase_uid:
+                from app.models import User
+                user = User.query.filter_by(supabase_user_id=supabase_uid).first()
+                if user:
+                    return user.id, None, None
+                # Supabase token is valid but user not synced yet
+                # This can happen on first login before /sync-user is called
+                current_app.logger.warning(
+                    f'Valid Supabase token but no local user for sub={supabase_uid}'
+                )
+                return None, 'User not found. Please complete registration.', 401
+        except jwt.ExpiredSignatureError:
+            return None, 'Token has expired', 401
+        except jwt.InvalidTokenError:
+            # Not a Supabase token, try legacy
+            pass
+
+    # --- Attempt 2: Legacy custom JWT (remove after migration #53) ---
+    try:
+        payload = jwt.decode(token, SECRET_KEY, algorithms=['HS256'])
+        user_id = payload.get('user_id')
+        if user_id:
+            return user_id, None, None
+        return None, 'Token is invalid', 401
+    except jwt.ExpiredSignatureError:
+        return None, 'Token has expired', 401
+    except jwt.InvalidTokenError:
+        return None, 'Token is invalid', 401
+
+
+def token_required(f):
+    """Decorator to require valid JWT token.
+
+    Supports both Supabase and legacy JWTs.
+    Extracts user_id and passes it as the first argument.
     """
     @wraps(f)
     def decorated(*args, **kwargs):
         auth_header = request.headers.get('Authorization')
-        
+
         if not auth_header:
             return jsonify({'error': 'Token is missing'}), 401
-        
-        try:
-            # Support both "Bearer <token>" and raw token formats
-            token = auth_header.split(' ')[1] if ' ' in auth_header else auth_header
-            payload = jwt.decode(token, SECRET_KEY, algorithms=['HS256'])
-            current_user_id = payload['user_id']
-        except jwt.ExpiredSignatureError:
-            return jsonify({'error': 'Token has expired'}), 401
-        except jwt.InvalidTokenError:
-            return jsonify({'error': 'Token is invalid'}), 401
-        except Exception as e:
-            return jsonify({'error': 'Token is invalid'}), 401
-        
-        return f(current_user_id, *args, **kwargs)
+
+        user_id, error, status = _resolve_user_from_token(auth_header)
+        if error:
+            return jsonify({'error': error}), status
+
+        return f(user_id, *args, **kwargs)
     return decorated
 
 
 def token_optional(f):
-    """
-    Decorator that optionally validates JWT token.
-    
+    """Decorator that optionally validates JWT token.
+
     If a valid token is provided, extracts user_id. Otherwise, passes None.
-    Useful for endpoints that work for both authenticated and anonymous users.
-    
-    Usage:
-        @app.route('/items')
-        @token_optional
-        def get_items(current_user_id):
-            # current_user_id is user's ID or None if not authenticated
-            if current_user_id:
-                # Show personalized content
-                pass
-            return jsonify({'items': items})
     """
     @wraps(f)
     def decorated(*args, **kwargs):
         auth_header = request.headers.get('Authorization')
         current_user_id = None
-        
+
         if auth_header:
-            try:
-                token = auth_header.split(' ')[1] if ' ' in auth_header else auth_header
-                payload = jwt.decode(token, SECRET_KEY, algorithms=['HS256'])
-                current_user_id = payload['user_id']
-            except:
-                pass  # Token invalid, but that's ok - it's optional
-        
+            user_id, error, status = _resolve_user_from_token(auth_header)
+            if not error:
+                current_user_id = user_id
+
         return f(current_user_id, *args, **kwargs)
     return decorated
 
 
 # ============ g.current_user variants ============
-# These set g.current_user (full User object) instead of passing user_id
-# Used by offerings.py and other routes that need the full user object
 
 def token_required_g(f):
-    """
-    Decorator to require valid JWT token, setting g.current_user.
-    
-    Sets g.current_user to the full User object for use in the route.
+    """Decorator to require valid JWT token, setting g.current_user.
+
+    Sets g.current_user to the full User object.
     Does NOT pass current_user_id as a parameter.
-    
-    Usage:
-        @app.route('/protected')
-        @token_required_g
-        def protected_route():
-            user = g.current_user
-            return jsonify({'user_id': user.id})
     """
     @wraps(f)
     def decorated(*args, **kwargs):
-        # Import here to avoid circular imports
         from app.models import User
-        
+
         auth_header = request.headers.get('Authorization')
-        
-        if not auth_header or not auth_header.startswith('Bearer '):
+
+        if not auth_header:
             return jsonify({'error': 'Token is missing'}), 401
-        
-        try:
-            token = auth_header.split(' ')[1]
-            payload = jwt.decode(token, SECRET_KEY, algorithms=['HS256'])
-            current_user = User.query.get(payload['user_id'])
-            if not current_user:
-                return jsonify({'error': 'User not found'}), 401
-            g.current_user = current_user
-        except jwt.ExpiredSignatureError:
-            return jsonify({'error': 'Token has expired'}), 401
-        except jwt.InvalidTokenError:
-            return jsonify({'error': 'Invalid token'}), 401
-        
+
+        user_id, error, status = _resolve_user_from_token(auth_header)
+        if error:
+            return jsonify({'error': error}), status
+
+        current_user = User.query.get(user_id)
+        if not current_user:
+            return jsonify({'error': 'User not found'}), 401
+        g.current_user = current_user
+
         return f(*args, **kwargs)
     return decorated
 
 
 def token_optional_g(f):
-    """
-    Decorator for optional JWT authentication, setting g.current_user.
-    
+    """Decorator for optional JWT authentication, setting g.current_user.
+
     Sets g.current_user to the User object if authenticated, None otherwise.
-    Does NOT pass current_user_id as a parameter.
-    
-    Usage:
-        @app.route('/items')
-        @token_optional_g
-        def get_items():
-            if g.current_user:
-                # Authenticated user
-                pass
-            return jsonify({'items': items})
     """
     @wraps(f)
     def decorated(*args, **kwargs):
         from app.models import User
-        
+
         g.current_user = None
         auth_header = request.headers.get('Authorization')
-        
-        if auth_header and auth_header.startswith('Bearer '):
-            try:
-                token = auth_header.split(' ')[1]
-                payload = jwt.decode(token, SECRET_KEY, algorithms=['HS256'])
-                current_user = User.query.get(payload['user_id'])
-                g.current_user = current_user
-            except (jwt.ExpiredSignatureError, jwt.InvalidTokenError):
-                pass
-        
+
+        if auth_header:
+            user_id, error, status = _resolve_user_from_token(auth_header)
+            if not error:
+                g.current_user = User.query.get(user_id)
+
         return f(*args, **kwargs)
     return decorated

--- a/migrations/versions/add_supabase_user_id.py
+++ b/migrations/versions/add_supabase_user_id.py
@@ -1,0 +1,30 @@
+"""Add supabase_user_id column to users table
+
+Revision ID: add_supabase_user_id
+Revises: merge_all_heads_feb2026
+Create Date: 2026-03-02
+
+Adds a UUID column to link local users to Supabase Auth users.
+Part of the Supabase Auth migration (#48).
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'add_supabase_user_id'
+down_revision = 'merge_all_heads_feb2026'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column('users', sa.Column('supabase_user_id', sa.String(36), nullable=True))
+    op.create_unique_constraint('uq_users_supabase_user_id', 'users', ['supabase_user_id'])
+    op.create_index('ix_users_supabase_user_id', 'users', ['supabase_user_id'])
+
+
+def downgrade():
+    op.drop_index('ix_users_supabase_user_id', table_name='users')
+    op.drop_constraint('uq_users_supabase_user_id', 'users', type_='unique')
+    op.drop_column('users', 'supabase_user_id')


### PR DESCRIPTION
Closes #50
Depends on: #49 ✅ (merged)
Parent: #48

## What
This is the core of the Supabase Auth migration — the decorators that protect every authenticated endpoint now understand Supabase JWTs.

## Changes

### `app/models/user.py`
- Added `supabase_user_id` column (`String(36)`, unique, nullable, indexed)
- This links each local user to their Supabase Auth UUID
- Everything else unchanged

### `app/utils/auth.py` — full rewrite
New `_resolve_user_from_token()` function that:
1. **Tries Supabase JWT first** — decodes with `SUPABASE_JWT_SECRET`, extracts `sub` (Supabase UUID), looks up user by `supabase_user_id`
2. **Falls back to legacy JWT** — decodes with `JWT_SECRET_KEY`, extracts `user_id` directly

This means **both old and new tokens work simultaneously** during migration. All four decorators use the same resolver:
- `token_required` → passes `user_id` as first arg
- `token_optional` → passes `user_id` or `None`
- `token_required_g` → sets `g.current_user`
- `token_optional_g` → sets `g.current_user` or `None`

### `migrations/versions/add_supabase_user_id.py`
- Adds the column + unique constraint + index
- Down revision: `merge_all_heads_feb2026`

## What this does NOT break
- All existing endpoints work exactly as before with old JWT tokens
- No frontend changes needed yet
- No Supabase configuration required yet (falls back to legacy if `SUPABASE_JWT_SECRET` is not set)

## After deploying
Run `flask db upgrade` to add the column.

## Next steps
→ #51: Create `/auth/sync-user` endpoint
→ #52: Update `/phone/verify` to create Supabase users
→ #54: Migration script to populate `supabase_user_id` for existing users

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ▶️ 2 queued — [View all](https://hub.continue.dev/inbox/pr/ojayWillow/marketplace-backend/56?utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->