### PR TITLE
feat: /phone/verify returns Supabase session tokens (#60)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,4 +23,5 @@ FRONTEND_URL=https://marketplace-frontend-tau-seven.vercel.app
 # Get these from: Supabase Dashboard -> Settings -> API
 SUPABASE_URL=https://your-project.supabase.co
 SUPABASE_SERVICE_KEY=your-service-role-key
+SUPABASE_ANON_KEY=your-anon-key
 SUPABASE_JWT_SECRET=your-jwt-secret-from-supabase-dashboard

--- a/app/routes/auth.py
+++ b/app/routes/auth.py
@@ -40,10 +40,11 @@ def _ensure_supabase_user(user, phone=None, email=None):
         email: Email to register with
 
     Returns:
-        supabase_user_id (str) or None if Supabase is not configured
+        Tuple of (supabase_user_id, password_used) or (supabase_user_id, None)
+        password_used is the password set on the Supabase user (needed for session generation)
     """
     if user.supabase_user_id:
-        return user.supabase_user_id
+        return user.supabase_user_id, None
 
     try:
         from app.services.supabase_auth import (
@@ -53,7 +54,7 @@ def _ensure_supabase_user(user, phone=None, email=None):
         )
     except (ImportError, RuntimeError):
         current_app.logger.debug('Supabase not available, skipping user creation')
-        return None
+        return None, None
 
     try:
         # Check if Supabase user already exists (e.g., created via another flow)
@@ -69,10 +70,10 @@ def _ensure_supabase_user(user, phone=None, email=None):
             current_app.logger.info(
                 f'Linked existing Supabase user {existing.id} to local user {user.id}'
             )
-            return user.supabase_user_id
+            return user.supabase_user_id, None
 
         # Create new Supabase Auth user
-        supabase_user = create_supabase_user(
+        supabase_user, password_used = create_supabase_user(
             phone=phone,
             email=email if email and not email.endswith('.kolab.local') else None,
             phone_confirm=True,
@@ -88,7 +89,7 @@ def _ensure_supabase_user(user, phone=None, email=None):
         current_app.logger.info(
             f'Created Supabase user {supabase_user.id} for local user {user.id}'
         )
-        return user.supabase_user_id
+        return user.supabase_user_id, password_used
 
     except Exception as e:
         current_app.logger.error(
@@ -96,7 +97,51 @@ def _ensure_supabase_user(user, phone=None, email=None):
         )
         current_app.logger.debug(traceback.format_exc())
         # Don't fail the request — legacy JWT still works
-        return None
+        return None, None
+
+
+def _generate_legacy_jwt(user):
+    """Generate a legacy custom JWT for backward compatibility.
+
+    Only used as a fallback when Supabase session generation fails.
+    Will be removed once all clients use Supabase sessions.
+    """
+    payload = {
+        'user_id': user.id,
+        'username': user.username,
+        'exp': datetime.utcnow() + timedelta(hours=24)
+    }
+    return jwt.encode(payload, SECRET_KEY, algorithm='HS256')
+
+
+def _build_session_response(user, is_new_user, supabase_session=None):
+    """Build a standardized auth response with session tokens.
+
+    If supabase_session is available, uses Supabase tokens.
+    Otherwise falls back to legacy JWT with a warning.
+    """
+    response_data = {
+        'message': 'Phone verification successful',
+        'user': user.to_dict(),
+        'is_new_user': is_new_user,
+    }
+
+    if supabase_session:
+        response_data['access_token'] = supabase_session['access_token']
+        response_data['refresh_token'] = supabase_session['refresh_token']
+        response_data['expires_in'] = supabase_session['expires_in']
+        response_data['expires_at'] = supabase_session['expires_at']
+        response_data['token_type'] = 'supabase'
+    else:
+        # Fallback to legacy JWT — log warning
+        current_app.logger.warning(
+            f'Falling back to legacy JWT for user {user.id} — '
+            'Supabase session generation failed'
+        )
+        response_data['access_token'] = _generate_legacy_jwt(user)
+        response_data['token_type'] = 'legacy'
+
+    return response_data
 
 
 @auth_bp.route('/register', methods=['POST'])
@@ -189,8 +234,10 @@ def phone_verify():
     """Firebase phone verification endpoint.
     
     Verifies a Firebase ID token and creates/logs in the user.
-    Also creates a Supabase Auth user (if Supabase is configured)
-    so the user is ready for the new auth system.
+    Creates a Supabase Auth user and returns a Supabase session
+    (access_token + refresh_token) for the frontend to use.
+
+    Falls back to legacy JWT if Supabase session generation fails.
     """
     try:
         try:
@@ -259,26 +306,28 @@ def phone_verify():
             current_app.logger.info(f"Phone login: new user created {user.id}")
         
         # --- Create/link Supabase Auth user ---
-        _ensure_supabase_user(user, phone=normalized_phone)
+        supabase_user_id, password_used = _ensure_supabase_user(
+            user, phone=normalized_phone
+        )
         
-        # Legacy JWT (still needed until frontend migrates to Supabase sessions)
-        payload = {
-            'user_id': user.id,
-            'username': user.username,
-            'exp': datetime.utcnow() + timedelta(hours=24)
-        }
-        token = jwt.encode(payload, SECRET_KEY, algorithm='HS256')
+        # --- Generate Supabase session ---
+        supabase_session = None
+        if supabase_user_id:
+            try:
+                from app.services.supabase_auth import generate_supabase_session
+                supabase_session = generate_supabase_session(
+                    email=user.email,
+                    phone=normalized_phone,
+                    password=password_used,
+                    supabase_user_id=supabase_user_id,
+                )
+            except Exception as e:
+                current_app.logger.error(
+                    f'Supabase session generation failed for user {user.id}: {e}'
+                )
+                current_app.logger.debug(traceback.format_exc())
         
-        response_data = {
-            'message': 'Phone verification successful',
-            'access_token': token,
-            'user': user.to_dict(),
-            'is_new_user': is_new_user
-        }
-        
-        # Include supabase_user_id so frontend knows when it can switch to Supabase auth
-        if user.supabase_user_id:
-            response_data['supabase_user_id'] = user.supabase_user_id
+        response_data = _build_session_response(user, is_new_user, supabase_session)
         
         return jsonify(response_data), 200
         

--- a/app/services/supabase_auth.py
+++ b/app/services/supabase_auth.py
@@ -9,8 +9,9 @@ Note: These use the SERVICE_KEY (admin access). Never expose to frontend.
 """
 
 import logging
-from typing import Optional
-from app.services.supabase_client import get_supabase_client
+import secrets
+from typing import Optional, Tuple
+from app.services.supabase_client import get_supabase_client, get_supabase_anon_client
 
 logger = logging.getLogger(__name__)
 
@@ -22,7 +23,7 @@ def create_supabase_user(
     email_confirm: bool = True,
     phone_confirm: bool = True,
     user_metadata: Optional[dict] = None,
-) -> dict:
+) -> Tuple:
     """Create a new user in Supabase Auth.
 
     Args:
@@ -34,7 +35,8 @@ def create_supabase_user(
         user_metadata: Additional metadata to store
 
     Returns:
-        Supabase user object dict
+        Tuple of (supabase_user, password_used)
+        password_used is needed for subsequent sign_in_with_password
 
     Raises:
         Exception if creation fails
@@ -43,7 +45,6 @@ def create_supabase_user(
     if not client:
         raise RuntimeError('Supabase client not available')
 
-    import secrets
     if not password:
         password = secrets.token_urlsafe(32)
 
@@ -59,7 +60,90 @@ def create_supabase_user(
 
     response = client.auth.admin.create_user(attrs)
     logger.info(f'Supabase user created: {response.user.id}')
-    return response.user
+    return response.user, password
+
+
+def generate_supabase_session(
+    email: Optional[str] = None,
+    phone: Optional[str] = None,
+    password: Optional[str] = None,
+    supabase_user_id: Optional[str] = None,
+) -> Optional[dict]:
+    """Generate a Supabase session (access_token + refresh_token) for a user.
+
+    Uses sign_in_with_password via the anon client. If no password is known,
+    sets a new random password via admin API first, then signs in.
+
+    Args:
+        email: User email (used for sign-in if available)
+        phone: User phone (used for sign-in if email not available)
+        password: Known password for the user
+        supabase_user_id: Supabase user UUID (needed to reset password if unknown)
+
+    Returns:
+        Dict with access_token, refresh_token, expires_in, expires_at
+        or None if session generation fails
+    """
+    anon_client = get_supabase_anon_client()
+    if not anon_client:
+        logger.warning('Anon client not available — cannot generate Supabase session')
+        return None
+
+    # If no password is known, set a new one via admin API
+    if not password:
+        if not supabase_user_id:
+            logger.error('Cannot generate session: no password and no supabase_user_id')
+            return None
+
+        admin_client = get_supabase_client()
+        if not admin_client:
+            logger.error('Admin client not available for password reset')
+            return None
+
+        password = secrets.token_urlsafe(32)
+        try:
+            admin_client.auth.admin.update_user(
+                supabase_user_id,
+                {'password': password}
+            )
+            logger.debug(f'Reset password for Supabase user {supabase_user_id}')
+        except Exception as e:
+            logger.error(f'Failed to reset password for session generation: {e}')
+            return None
+
+    # Sign in to get a real session
+    try:
+        credentials = {'password': password}
+
+        # Prefer email for sign-in (more reliable), fall back to phone
+        if email and not email.endswith('.kolab.local'):
+            credentials['email'] = email
+        elif phone:
+            credentials['phone'] = phone
+        elif email:
+            # Use placeholder email as last resort
+            credentials['email'] = email
+        else:
+            logger.error('No email or phone available for sign-in')
+            return None
+
+        response = anon_client.auth.sign_in_with_password(credentials)
+
+        if response.session:
+            logger.info('Supabase session generated successfully')
+            return {
+                'access_token': response.session.access_token,
+                'refresh_token': response.session.refresh_token,
+                'expires_in': response.session.expires_in,
+                'expires_at': response.session.expires_at,
+            }
+        else:
+            logger.error('sign_in_with_password returned no session')
+            return None
+
+    except Exception as e:
+        logger.error(f'Failed to generate Supabase session: {e}')
+        return None
 
 
 def get_supabase_user_by_id(user_id: str):

--- a/app/services/supabase_client.py
+++ b/app/services/supabase_client.py
@@ -1,7 +1,11 @@
-"""Shared Supabase client.
+"""Shared Supabase clients.
 
-Single source of truth for the Supabase client instance.
-Used by storage, auth, and any other service that needs Supabase.
+Provides two clients:
+1. Service-role client (admin) — for user management, storage, etc.
+2. Anon client — for generating user sessions via sign_in_with_password
+
+The service-role client has admin privileges and should never be exposed.
+The anon client uses the public anon key and is safe for session operations.
 """
 
 import os
@@ -10,10 +14,11 @@ import logging
 logger = logging.getLogger(__name__)
 
 _supabase_client = None
+_supabase_anon_client = None
 
 
 def get_supabase_client():
-    """Get or create Supabase client (lazy initialization)."""
+    """Get or create Supabase admin client (service role key)."""
     global _supabase_client
 
     if _supabase_client is None:
@@ -27,12 +32,41 @@ def get_supabase_client():
         try:
             from supabase import create_client
             _supabase_client = create_client(url, key)
-            logger.info('Supabase client initialized successfully')
+            logger.info('Supabase admin client initialized successfully')
         except Exception as e:
-            logger.error(f'Failed to initialize Supabase client: {e}')
+            logger.error(f'Failed to initialize Supabase admin client: {e}')
             return None
 
     return _supabase_client
+
+
+def get_supabase_anon_client():
+    """Get or create Supabase anon client (public anon key).
+
+    Used for operations that need a user session, such as
+    sign_in_with_password() to generate access/refresh tokens.
+
+    The anon key is the public key from Supabase Dashboard > Settings > API.
+    """
+    global _supabase_anon_client
+
+    if _supabase_anon_client is None:
+        url = os.getenv('SUPABASE_URL')
+        key = os.getenv('SUPABASE_ANON_KEY')
+
+        if not url or not key:
+            logger.warning('SUPABASE_ANON_KEY not configured — session generation unavailable.')
+            return None
+
+        try:
+            from supabase import create_client
+            _supabase_anon_client = create_client(url, key)
+            logger.info('Supabase anon client initialized successfully')
+        except Exception as e:
+            logger.error(f'Failed to initialize Supabase anon client: {e}')
+            return None
+
+    return _supabase_anon_client
 
 
 def get_supabase_jwt_secret() -> str:


### PR DESCRIPTION
## What

Updates `/phone/verify` to return **real Supabase session tokens** (access_token + refresh_token) instead of legacy custom JWTs.

Closes #60

## Changes

### `app/services/supabase_client.py`
- Added `get_supabase_anon_client()` — uses `SUPABASE_ANON_KEY` for session operations (sign_in_with_password)
- Service-role client unchanged

### `app/services/supabase_auth.py`
- `create_supabase_user()` now returns `(user, password_used)` tuple so the password is available for session generation
- Added `generate_supabase_session()` — signs in via anon client to get access_token + refresh_token. If no password is known (existing Supabase user), resets password via admin API first.

### `app/routes/auth.py`
- `_ensure_supabase_user()` now returns `(supabase_user_id, password_used)` tuple
- Added `_generate_legacy_jwt()` helper — extracted legacy JWT logic
- Added `_build_session_response()` — standardized response builder that uses Supabase session if available, falls back to legacy JWT with a warning log
- `phone_verify()` now calls `generate_supabase_session()` after ensuring the Supabase user exists
- **`/phone/link` and `/complete-registration` NOT changed** — tracked in #61

### `.env.example`
- Added `SUPABASE_ANON_KEY`

## New response format from `/phone/verify`

```json
{
  "message": "Phone verification successful",
  "access_token": "<supabase JWT>",
  "refresh_token": "<supabase refresh token>",
  "expires_in": 3600,
  "expires_at": 1234567890,
  "token_type": "supabase",
  "user": { ... },
  "is_new_user": true
}
```

If Supabase session generation fails, falls back to legacy JWT with `"token_type": "legacy"`.

## How session generation works

1. Firebase OTP verifies the phone → `/phone/verify` called
2. `_ensure_supabase_user()` creates/links Supabase user, returns the password used
3. `generate_supabase_session()` calls `sign_in_with_password()` via anon client
4. Returns Supabase access_token + refresh_token to frontend
5. Frontend uses `supabase.auth.setSession()` with these tokens

For **existing** Supabase users (password unknown), step 3 resets the password via admin API first, then signs in.

## Testing

- [ ] New user phone verification returns Supabase tokens
- [ ] Existing user phone login returns Supabase tokens
- [ ] Fallback to legacy JWT when Supabase is not configured
- [ ] Token is accepted by `token_required` decorator
- [ ] `SUPABASE_ANON_KEY` env variable is required for session generation

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ▶️ 2 queued — [View all](https://hub.continue.dev/inbox/pr/ojayWillow/marketplace-backend/63?utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->