### PR TITLE
🚀 Phase 1: Fix premium pricing, per-type durations & sorting alignment

### DIFF
--- a/app/models/payment.py
+++ b/app/models/payment.py
@@ -39,8 +39,8 @@ class Payment(db.Model):
     # Valid payment types and their prices in cents
     PRICES = {
         'urgent_task': 200,       # €2.00
-        'promote_task': 100,      # €1.00
-        'promote_offering': 100,  # €1.00
+        'promote_task': 500,      # €5.00
+        'promote_offering': 500,  # €5.00
         'boost_offering': 100,    # €1.00
     }
     

--- a/app/routes/payments.py
+++ b/app/routes/payments.py
@@ -19,8 +19,13 @@ logger = logging.getLogger(__name__)
 
 payments_bp = Blueprint('payments', __name__)
 
-# Duration for paid features
-FEATURE_DURATION = timedelta(hours=24)
+# Duration per premium feature type
+FEATURE_DURATIONS = {
+    'urgent_task': timedelta(hours=24),
+    'promote_task': timedelta(days=3),
+    'promote_offering': timedelta(days=3),
+    'boost_offering': timedelta(hours=24),
+}
 
 
 @payments_bp.route('/create-order', methods=['POST'])
@@ -30,7 +35,7 @@ def create_order(current_user_id):
     
     Body:
         type: str — 'urgent_task', 'promote_task', 'promote_offering', 'boost_offering'
-        entity_id: int — task_request.id or offering.id
+        entity_id: int — task_request.id or offering.id (also accepts 'target_id')
     
     Returns:
         { checkout_url: str, order_id: str }
@@ -40,7 +45,7 @@ def create_order(current_user_id):
         return jsonify({'error': 'Request body is required'}), 400
     
     payment_type = data.get('type')
-    entity_id = data.get('entity_id')
+    entity_id = data.get('entity_id') or data.get('target_id')
     
     # Validate payment type
     if not Payment.is_valid_type(payment_type):
@@ -226,12 +231,18 @@ def _activate_feature(payment):
     """Activate the paid feature for a payment.
     
     Sets the appropriate flags and expiration on the entity.
+    Uses per-type durations from FEATURE_DURATIONS.
     
     Returns:
         True on success, False on failure
     """
     now = datetime.utcnow()
-    expires_at = now + FEATURE_DURATION
+    duration = FEATURE_DURATIONS.get(payment.type)
+    if not duration:
+        logger.error(f'No duration defined for payment type: {payment.type}')
+        return False
+    
+    expires_at = now + duration
     
     try:
         if payment.type == 'urgent_task':
@@ -271,6 +282,7 @@ def _activate_feature(payment):
             return False
         
         db.session.flush()
+        logger.info(f'Feature {payment.type} activated for entity {payment.entity_id}, expires at {expires_at}')
         return True
         
     except Exception as e:

--- a/app/routes/tasks/queries.py
+++ b/app/routes/tasks/queries.py
@@ -1,12 +1,31 @@
 """User-specific task query routes (my tasks, created tasks, notifications)."""
 
+from datetime import datetime
 from flask import request, jsonify
+from sqlalchemy import case
 from sqlalchemy.orm import joinedload
 from app import db
 from app.models import TaskRequest, User, TaskApplication
 from app.utils import token_required
 from app.routes.tasks import tasks_bp
 from app.routes.tasks.helpers import translate_task_if_needed
+
+
+def _premium_order_by():
+    """SQLAlchemy order_by clause that sorts premium tasks first.
+    
+    Order: promoted (active) → urgent (active) → regular, then newest.
+    """
+    now = datetime.utcnow()
+    return [
+        case(
+            (db.and_(TaskRequest.is_promoted == True, TaskRequest.promoted_expires_at > now), 0),
+            (db.and_(TaskRequest.is_urgent == True, TaskRequest.urgent_expires_at > now), 1),
+            (db.and_(TaskRequest.is_urgent == True, TaskRequest.urgent_expires_at.is_(None)), 1),
+            else_=2
+        ),
+        TaskRequest.created_at.desc()
+    ]
 
 
 @tasks_bp.route('/notifications', methods=['GET'])
@@ -59,20 +78,13 @@ def get_my_tasks(current_user_id):
     try:
         lang = request.args.get('lang')
         
-        # Include all statuses where the worker is involved:
-        # - assigned: accepted but not started
-        # - accepted: legacy status (same as assigned)
-        # - in_progress: worker is working on it
-        # - pending_confirmation: worker marked done, waiting for creator
-        # - completed: task is done
-        # - disputed: task has an active dispute
         my_tasks = TaskRequest.query.options(
             joinedload(TaskRequest.creator),
             joinedload(TaskRequest.assigned_user)
         ).filter(
             TaskRequest.assigned_to_id == current_user_id,
             TaskRequest.status.in_(['assigned', 'accepted', 'in_progress', 'pending_confirmation', 'completed', 'disputed'])
-        ).order_by(TaskRequest.created_at.desc()).all()
+        ).order_by(*_premium_order_by()).all()
         
         tasks_list = [translate_task_if_needed(task.to_dict(), lang) for task in my_tasks]
         
@@ -96,7 +108,7 @@ def get_created_tasks(current_user_id):
             joinedload(TaskRequest.assigned_user)
         ).filter(
             TaskRequest.creator_id == current_user_id
-        ).order_by(TaskRequest.created_at.desc()).all()
+        ).order_by(*_premium_order_by()).all()
         
         results = []
         for task in created_tasks:
@@ -132,7 +144,7 @@ def get_user_tasks(user_id):
         ).filter_by(
             creator_id=user_id,
             status='open'
-        ).order_by(TaskRequest.created_at.desc()).all()
+        ).order_by(*_premium_order_by()).all()
         
         tasks_list = [translate_task_if_needed(task.to_dict(), lang) for task in tasks]
         

--- a/app/routes/tasks/search.py
+++ b/app/routes/tasks/search.py
@@ -182,6 +182,21 @@ def task_matches_search(task, search_patterns: list) -> bool:
     return False
 
 
+def _premium_sort_key(task_dict):
+    """Sort key for premium ordering: promoted first, then urgent, then regular.
+    
+    Returns an int where:
+    - 0 = active promoted
+    - 1 = active urgent
+    - 2 = regular
+    """
+    if task_dict.get('is_promote_active'):
+        return 0
+    if task_dict.get('is_urgent_active'):
+        return 1
+    return 2
+
+
 @tasks_bp.route('/search', methods=['GET'])
 def search_tasks():
     """Search for tasks with fuzzy matching and multilingual support.
@@ -192,6 +207,7 @@ def search_tasks():
     - Stem matching (sniegs finds sniegu)
     - Multilingual: searches original + all translations (LV, EN, RU)
     - User can search 'snow' and find Latvian task 'tīrīt sniegu'
+    - Premium sorting: promoted → urgent → regular
     
     Query params:
         - q: Search query string (required)
@@ -264,8 +280,8 @@ def search_tasks():
                     task_dict = translate_task_if_needed(task_dict, lang)
                     tasks_with_distance.append(task_dict)
             
-            # Sort by distance
-            tasks_with_distance.sort(key=lambda x: x['distance'])
+            # Sort: promoted first → urgent second → then by distance
+            tasks_with_distance.sort(key=lambda x: (_premium_sort_key(x), x['distance']))
             
             total = len(tasks_with_distance)
             start = (page - 1) * per_page
@@ -288,6 +304,9 @@ def search_tasks():
                 task_dict = translate_task_if_needed(task.to_dict(), lang)
                 task_dict['pending_applications_count'] = get_pending_applications_count(task.id)
                 tasks_list.append(task_dict)
+            
+            # Sort: promoted first → urgent second → then by date (already desc)
+            tasks_list.sort(key=lambda x: _premium_sort_key(x))
             
             total = len(tasks_list)
             start = (page - 1) * per_page


### PR DESCRIPTION
## Summary

Phase 1 of the Premium Features Overhaul (#70). Fixes pricing misalignment between frontend and backend, adds per-type feature durations, and ensures all listing/search endpoints sort premium items first.

## Changes

### 1. Fix `Payment.PRICES` (`app/models/payment.py`)
| Type | Before | After |
|------|--------|-------|
| `urgent_task` | €2.00 ✅ | €2.00 |
| `promote_task` | €1.00 ❌ | **€5.00** |
| `promote_offering` | €1.00 ❌ | **€5.00** |
| `boost_offering` | €1.00 ✅ | €1.00 |

### 2. Per-type durations (`app/routes/payments.py`)
Replaced flat `FEATURE_DURATION = timedelta(hours=24)` with:
| Type | Duration |
|------|----------|
| `urgent_task` | 24 hours |
| `promote_task` | **3 days** |
| `promote_offering` | **3 days** |
| `boost_offering` | 24 hours |

### 3. Accept `target_id` alias (`app/routes/payments.py`)
`entity_id = data.get('entity_id') or data.get('target_id')` — frontend sends `target_id`, now both work.

### 4. Premium sorting in search (`app/routes/tasks/search.py`)
Added `_premium_sort_key()` — search results now sort: promoted → urgent → regular (then by distance or date). This was the only task listing endpoint missing premium sorting.

### 5. Premium sorting in queries (`app/routes/tasks/queries.py`)
Added `_premium_order_by()` helper used by `/my`, `/created`, `/user/<id>` — all now sort premium tasks first.

## What was already working
- `crud.py` GET `/tasks` — already had premium sorting ✅
- `offerings.py` GET `/offerings` — already had premium sorting ✅
- `task_request.py` `to_dict()` — already exposes `is_urgent_active`, `is_promote_active` ✅
- `offering.py` `to_dict()` — already exposes `is_boost_active`, `is_promote_active` ✅

## No migrations needed
No model schema changes — only price constants, duration logic, and query ordering.

Closes Phase 1 of #70

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ▶️ 2 queued — [View all](https://hub.continue.dev/inbox/pr/ojayWillow/marketplace-backend/71?utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->