### PR TITLE
fix: migrate push.py and uploads.py to Supabase auth

### DIFF
--- a/app/routes/push.py
+++ b/app/routes/push.py
@@ -1,41 +1,16 @@
 """Push notification subscription routes."""
 
 from flask import Blueprint, request, jsonify
-from functools import wraps
-import jwt
 import os
 
 from app import db
 from app.models import PushSubscription
+from app.utils import token_required
 
 push_bp = Blueprint('push', __name__)
 
-SECRET_KEY = os.getenv('JWT_SECRET_KEY', 'your-secret-key-here')
-
 # Get VAPID public key for frontend
 VAPID_PUBLIC_KEY = os.getenv('VAPID_PUBLIC_KEY', '')
-
-
-def token_required(f):
-    """Decorator to require valid JWT token."""
-    @wraps(f)
-    def decorated(*args, **kwargs):
-        auth_header = request.headers.get('Authorization')
-        
-        if not auth_header:
-            return jsonify({'error': 'Token is missing'}), 401
-        
-        try:
-            token = auth_header.split(' ')[1] if ' ' in auth_header else auth_header
-            payload = jwt.decode(token, SECRET_KEY, algorithms=['HS256'])
-            current_user_id = payload['user_id']
-        except jwt.ExpiredSignatureError:
-            return jsonify({'error': 'Token has expired'}), 401
-        except Exception as e:
-            return jsonify({'error': 'Token is invalid', 'details': str(e)}), 401
-        
-        return f(current_user_id, *args, **kwargs)
-    return decorated
 
 
 @push_bp.route('/vapid-public-key', methods=['GET'])
@@ -198,7 +173,7 @@ def send_test_notification(current_user_id):
     
     result = send_push_notification(
         user_id=current_user_id,
-        title='🔔 Test Notification',
+        title='\ud83d\udd14 Test Notification',
         body='Push notifications are working!',
         url='/'
     )

--- a/app/routes/uploads.py
+++ b/app/routes/uploads.py
@@ -7,9 +7,6 @@ Supports uploading images for:
 """
 
 from flask import Blueprint, request, jsonify
-import os
-import jwt
-from functools import wraps
 import logging
 
 from app.services.storage import (
@@ -20,12 +17,10 @@ from app.services.storage import (
     is_storage_configured
 )
 from app import db
+from app.utils import token_required
 
 uploads_bp = Blueprint('uploads', __name__)
 logger = logging.getLogger(__name__)
-
-# Use the same key as Flask-JWT-Extended configuration
-SECRET_KEY = os.getenv('JWT_SECRET_KEY', 'your-secret-key-here')
 
 # Allowed file extensions
 IMAGE_EXTENSIONS = {'png', 'jpg', 'jpeg', 'gif', 'webp', 'heic'}
@@ -34,29 +29,6 @@ IMAGE_EXTENSIONS = {'png', 'jpg', 'jpeg', 'gif', 'webp', 'heic'}
 AVATAR_MAX_SIZE = 5 * 1024 * 1024  # 5MB
 TASK_IMAGE_MAX_SIZE = 10 * 1024 * 1024  # 10MB
 CHAT_IMAGE_MAX_SIZE = 10 * 1024 * 1024  # 10MB
-
-
-def token_required(f):
-    @wraps(f)
-    def decorated(*args, **kwargs):
-        token = request.headers.get('Authorization')
-        if not token:
-            logger.warning('Upload attempt without auth token')
-            return jsonify({'error': 'Token is missing'}), 401
-        
-        try:
-            token = token.split(' ')[1] if ' ' in token else token
-            data = jwt.decode(token, SECRET_KEY, algorithms=['HS256'])
-            current_user_id = data['user_id']
-        except jwt.ExpiredSignatureError:
-            logger.warning('Upload attempt with expired token')
-            return jsonify({'error': 'Token has expired'}), 401
-        except Exception as e:
-            logger.warning(f'Upload attempt with invalid token: {e}')
-            return jsonify({'error': 'Token is invalid'}), 401
-        
-        return f(current_user_id, *args, **kwargs)
-    return decorated
 
 
 def allowed_image(filename):


### PR DESCRIPTION
## Problem

Two route files still had **local `token_required` decorators** using the old JWT system (`JWT_SECRET_KEY` + HS256 + `payload['user_id']`), causing **401 errors** for all authenticated users on these endpoints.

The frontend sends Supabase JWTs, but these files tried to verify them with the wrong key/algorithm and read a field (`user_id`) that doesn't exist in Supabase tokens.

## What Changed

### `app/routes/push.py`
- ❌ Removed local `token_required` decorator (old JWT)
- ❌ Removed `SECRET_KEY = os.getenv('JWT_SECRET_KEY', ...)`
- ❌ Removed unused imports: `jwt`, `functools.wraps`
- ✅ Added `from app.utils import token_required` (shared Supabase auth)

### `app/routes/uploads.py`
- ❌ Removed local `token_required` decorator (old JWT)
- ❌ Removed `SECRET_KEY = os.getenv('JWT_SECRET_KEY', ...)`
- ❌ Removed unused imports: `jwt`, `os`, `functools.wraps`
- ✅ Added `from app.utils import token_required` (shared Supabase auth)

## Endpoints Fixed

| Endpoint | File | Was broken |
|----------|------|------------|
| `POST /api/push/subscribe` | push.py | ✅ Fixed |
| `POST /api/push/unsubscribe` | push.py | ✅ Fixed |
| `GET /api/push/subscriptions` | push.py | ✅ Fixed |
| `POST /api/push/test` | push.py | ✅ Fixed |
| `POST /api/uploads/avatar` | uploads.py | ✅ Fixed |
| `POST /api/uploads/task-image` | uploads.py | ✅ Fixed |
| `POST /api/uploads/chat-image` | uploads.py | ✅ Fixed |
| `POST /api/uploads` (legacy) | uploads.py | ✅ Fixed |

## No Breaking Changes

All route function signatures already accepted `current_user_id` as the first parameter — the shared decorator passes the same argument. Zero logic changes needed.

## Testing

- [ ] Push notification test button works (Job Alerts page)
- [ ] Avatar upload works (profile settings)
- [ ] Task image upload works (create/edit task)
- [ ] Chat image upload works (messaging)

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ▶️ 2 queued — [View all](https://hub.continue.dev/inbox/pr/ojayWillow/marketplace-backend/72?utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->