### PR TITLE
fix: add missing push notifications for job alerts and review reminders

### DIFF
--- a/app/routes/tasks/workflow.py
+++ b/app/routes/tasks/workflow.py
@@ -7,7 +7,8 @@ from app.services.push_notifications import (
     notify_task_marked_done,
     notify_task_confirmed,
     notify_task_disputed as push_notify_disputed,
-    notify_task_cancelled as push_notify_cancelled
+    notify_task_cancelled as push_notify_cancelled,
+    notify_review_reminder as push_notify_review_reminder
 )
 from app.utils import token_required, get_display_name, send_push_safe
 from app.routes.tasks import tasks_bp
@@ -120,6 +121,30 @@ def confirm_task_completion(current_user_id, task_id):
         except Exception as notify_error:
             db.session.rollback()
             print(f"In-app notification skipped (non-critical): {notify_error}")
+        
+        # Push notifications for review reminders
+        creator = User.query.get(current_user_id)
+        creator_name = get_display_name(creator)
+        worker = User.query.get(worker_id)
+        worker_name = get_display_name(worker)
+        
+        # Review reminder push to worker (to review the creator)
+        send_push_safe(
+            push_notify_review_reminder,
+            user_id=worker_id,
+            other_party_name=creator_name,
+            task_title=task_title,
+            task_id=task_id
+        )
+        
+        # Review reminder push to creator (to review the worker)
+        send_push_safe(
+            push_notify_review_reminder,
+            user_id=current_user_id,
+            other_party_name=worker_name,
+            task_title=task_title,
+            task_id=task_id
+        )
         
         return jsonify({
             'message': 'Task completed! Both parties can now leave reviews.',

--- a/app/services/job_alerts.py
+++ b/app/services/job_alerts.py
@@ -14,6 +14,7 @@ import logging
 from app import db
 from app.models import User
 from app.routes.tasks.helpers import distance
+from app.utils import send_push_safe
 
 logger = logging.getLogger(__name__)
 
@@ -32,6 +33,7 @@ def send_job_alerts_for_task(task) -> int:
         Number of notifications created
     """
     from app.routes.notifications import notify_new_task_nearby
+    from app.services.push_notifications import notify_new_job_nearby
     
     # Task must have coordinates
     if task.latitude is None or task.longitude is None:
@@ -78,7 +80,7 @@ def send_job_alerts_for_task(task) -> int:
         if task.budget:
             budget_display = f'\u20ac{task.budget}'
         
-        # Create notification
+        # Create in-app notification
         try:
             notify_new_task_nearby(
                 user_id=user.id,
@@ -93,6 +95,15 @@ def send_job_alerts_for_task(task) -> int:
         except Exception as e:
             logger.error(f'Error creating job alert for user {user.id}: {e}')
             continue
+        
+        # Send push notification
+        send_push_safe(
+            notify_new_job_nearby,
+            user_id=user.id,
+            task_title=task.title,
+            task_id=task.id,
+            distance_km=round(dist, 1)
+        )
     
     if notified > 0:
         try:

--- a/app/services/push_notifications.py
+++ b/app/services/push_notifications.py
@@ -150,7 +150,7 @@ def notify_new_message(recipient_id: int, sender_name: str, message_preview: str
     logger.info(f'[PUSH] notify_new_message called - recipient: {recipient_id}, sender: {sender_name}')
     return send_push_notification(
         user_id=recipient_id,
-        title=f'💬 {sender_name}',
+        title=f'\U0001f4ac {sender_name}',
         body=message_preview[:100] + ('...' if len(message_preview) > 100 else ''),
         url=f'/messages/{conversation_id}',
         tag=f'message-{conversation_id}'  # Replace previous messages from same conversation
@@ -165,7 +165,7 @@ def notify_application_received(task_owner_id: int, applicant_name: str,
     logger.info(f'[PUSH] notify_application_received called - owner: {task_owner_id}')
     return send_push_notification(
         user_id=task_owner_id,
-        title='👋 New Application!',
+        title='\U0001f44b New Application!',
         body=f'{applicant_name} applied for "{task_title}"',
         url=f'/tasks/{task_id}',
         tag=f'application-{task_id}'
@@ -179,7 +179,7 @@ def notify_application_accepted(applicant_id: int, task_title: str, task_id: int
     logger.info(f'[PUSH] notify_application_accepted called - applicant: {applicant_id}')
     return send_push_notification(
         user_id=applicant_id,
-        title='🎉 Application Accepted!',
+        title='\U0001f389 Application Accepted!',
         body=f'You got the job! "{task_title}"',
         url=f'/tasks/{task_id}',
         tag=f'accepted-{task_id}'
@@ -208,7 +208,7 @@ def notify_task_marked_done(task_owner_id: int, worker_name: str,
     logger.info(f'[PUSH] notify_task_marked_done called - owner: {task_owner_id}')
     return send_push_notification(
         user_id=task_owner_id,
-        title='✅ Task Completed',
+        title='\u2705 Task Completed',
         body=f'{worker_name} finished "{task_title}". Please review.',
         url=f'/tasks/{task_id}',
         tag=f'done-{task_id}'
@@ -222,7 +222,7 @@ def notify_task_confirmed(worker_id: int, task_title: str, task_id: int):
     logger.info(f'[PUSH] notify_task_confirmed called - worker: {worker_id}')
     return send_push_notification(
         user_id=worker_id,
-        title='🌟 Great job!',
+        title='\U0001f31f Great job!',
         body=f'"{task_title}" has been confirmed complete.',
         url=f'/tasks/{task_id}',
         tag=f'confirmed-{task_id}'
@@ -236,7 +236,7 @@ def notify_task_disputed(user_id: int, task_title: str, task_id: int):
     logger.info(f'[PUSH] notify_task_disputed called - user: {user_id}')
     return send_push_notification(
         user_id=user_id,
-        title='⚠️ Task Disputed',
+        title='\u26a0\ufe0f Task Disputed',
         body=f'A dispute has been raised for "{task_title}". Please check.',
         url=f'/tasks/{task_id}',
         tag=f'disputed-{task_id}'
@@ -250,7 +250,7 @@ def notify_task_cancelled(user_id: int, task_title: str, task_id: int):
     logger.info(f'[PUSH] notify_task_cancelled called - user: {user_id}')
     return send_push_notification(
         user_id=user_id,
-        title='❌ Task Cancelled',
+        title='\u274c Task Cancelled',
         body=f'The task "{task_title}" has been cancelled.',
         url=f'/tasks/{task_id}',
         tag=f'cancelled-{task_id}'
@@ -263,7 +263,7 @@ def notify_new_review(user_id: int, reviewer_name: str, task_title: str,
     Send push notification when someone leaves a review for you.
     """
     logger.info(f'[PUSH] notify_new_review called - user: {user_id}')
-    stars = '⭐' * min(rating, 5)
+    stars = '\u2b50' * min(rating, 5)
     return send_push_notification(
         user_id=user_id,
         title=f'{stars} New Review!',
@@ -276,13 +276,28 @@ def notify_new_review(user_id: int, reviewer_name: str, task_title: str,
 def notify_new_job_nearby(user_id: int, task_title: str, task_id: int, 
                           distance_km: float):
     """
-    Send push notification for new job posted nearby (optional feature).
+    Send push notification for new job posted nearby.
     """
     logger.info(f'[PUSH] notify_new_job_nearby called - user: {user_id}')
     return send_push_notification(
         user_id=user_id,
-        title='💼 New Job Nearby!',
+        title='\U0001f4bc New Job Nearby!',
         body=f'"{task_title}" - {distance_km:.1f}km away',
         url=f'/tasks/{task_id}',
         tag='new-job-nearby'
+    )
+
+
+def notify_review_reminder(user_id: int, other_party_name: str, 
+                           task_title: str, task_id: int):
+    """
+    Send push notification reminding user to leave a review after task completion.
+    """
+    logger.info(f'[PUSH] notify_review_reminder called - user: {user_id}')
+    return send_push_notification(
+        user_id=user_id,
+        title='\u270d\ufe0f Leave a Review',
+        body=f'How was working with {other_party_name} on "{task_title}"?',
+        url=f'/tasks/{task_id}',
+        tag=f'review-reminder-{task_id}'
     )


### PR DESCRIPTION
## Problem

Two notification types were only firing as in-app notifications without an accompanying push notification:

1. **Job alerts (new task nearby)** — `job_alerts.py` only called `notify_new_task_nearby` (in-app) but never sent a push via `notify_new_job_nearby`, even though the push helper already existed.

2. **Review reminders** — When a task is confirmed complete, review reminder in-app notifications were sent to both parties, but no push notification was sent. The push helper function didn't exist yet.

## Changes

### `app/services/push_notifications.py`
- Added `notify_review_reminder()` helper — sends a push like *"✍️ Leave a Review — How was working with {name} on {task}?"*

### `app/services/job_alerts.py`
- Added `send_push_safe(notify_new_job_nearby, ...)` call after each in-app job alert notification
- Imported `send_push_safe` from utils and `notify_new_job_nearby` from push service

### `app/routes/tasks/workflow.py`
- Imported `notify_review_reminder` from push_notifications
- In `confirm_task_completion`: added two push calls — one to the worker (to review the creator) and one to the creator (to review the worker)

## Result

All notification types now fire both in-app + push:

| Event | In-app | Push |
|---|---|---|
| New application | ✅ | ✅ |
| Application accepted | ✅ | ✅ |
| Application rejected | ✅ | ✅ |
| Task marked done | ✅ | ✅ |
| Task confirmed | ✅ | ✅ |
| Task disputed | ✅ | ✅ |
| Task cancelled | ✅ | ✅ |
| New review | ✅ | ✅ |
| New message | — | ✅ |
| **Job alert (new task nearby)** | ✅ | ✅ 🆕 |
| **Review reminder** | ✅ | ✅ 🆕 |

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ▶️ 2 queued — [View all](https://hub.continue.dev/inbox/pr/ojayWillow/marketplace-backend/75?utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->