### PR TITLE
Add rate limiting and throttle last_seen updates

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -3,7 +3,10 @@ from flask_sqlalchemy import SQLAlchemy
 from flask_migrate import Migrate
 from flask_cors import CORS
 from flask_socketio import SocketIO
+from flask_limiter import Limiter
+from flask_limiter.util import get_remote_address
 import os
+from datetime import datetime, timezone, timedelta
 from dotenv import load_dotenv
 
 load_dotenv()
@@ -11,6 +14,11 @@ load_dotenv()
 db = SQLAlchemy()
 migrate = Migrate()
 socketio = SocketIO()
+limiter = Limiter(
+    key_func=get_remote_address,
+    default_limits=["60 per minute"],
+    storage_uri="memory://",
+)
 
 def create_app(config_name=None):
     app = Flask(__name__)
@@ -48,6 +56,12 @@ def create_app(config_name=None):
     # Initialize extensions
     db.init_app(app)
     migrate.init_app(app, db)
+    
+    # Initialize rate limiter
+    # Disable rate limiting during tests
+    if config_name == 'testing':
+        app.config['RATELIMIT_ENABLED'] = False
+    limiter.init_app(app)
     
     # Allowed origins for CORS
     allowed_origins = [
@@ -216,9 +230,13 @@ def create_app(config_name=None):
          methods=["GET", "POST", "PUT", "DELETE", "OPTIONS", "PATCH"])
     
     # Middleware to update user's last_seen on authenticated requests
+    # Throttled: only updates if last_seen is older than 5 minutes
+    LAST_SEEN_THROTTLE = timedelta(minutes=5)
+    
     @app.before_request
     def update_last_seen():
-        """Update user's last_seen timestamp on every authenticated request."""
+        """Update user's last_seen timestamp on every authenticated request.
+        Throttled to only write to DB if last update was >5 minutes ago."""
         # Skip for OPTIONS requests (CORS preflight)
         if request.method == 'OPTIONS':
             return
@@ -242,8 +260,11 @@ def create_app(config_name=None):
             from app.models import User
             user = User.query.get(user_id)
             if user:
-                user.update_last_seen()
-                db.session.commit()
+                now = datetime.now(timezone.utc)
+                # Only update if last_seen is older than 5 minutes
+                if user.last_seen is None or (now - user.last_seen.replace(tzinfo=timezone.utc)) > LAST_SEEN_THROTTLE:
+                    user.update_last_seen()
+                    db.session.commit()
         except Exception:
             # Silently ignore errors - don't break the request
             pass

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,3 +19,4 @@ requests>=2.31.0
 resend==0.8.0
 supabase>=2.0.0
 stripe>=7.0.0
+Flask-Limiter==3.5.1


### PR DESCRIPTION
## Changes

### 1. Rate Limiting (Flask-Limiter)
- Added `Flask-Limiter==3.5.1` to requirements.txt
- Configured global rate limiter: **60 requests/minute** per IP (default)
- Uses in-memory storage (suitable for single-instance Railway deployment)
- Rate limiting is **disabled during tests** so test suite isn't affected
- Individual route-level limits (e.g. login, register) can be added by decorating routes with `@limiter.limit()`

### 2. Last Seen Throttling
- Previously: every authenticated request triggered a DB write to update `last_seen`
- Now: only updates `last_seen` if the previous value is **older than 5 minutes**
- Reduces unnecessary DB writes from ~100/session to ~2-3/session

### No Breaking Changes
- All existing functionality preserved
- Rate limiter disabled in test environment
- `last_seen` still works, just writes less frequently

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ▶️ 2 queued — [View all](https://hub.continue.dev/inbox/pr/ojayWillow/marketplace-backend/78?utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->